### PR TITLE
Correct instructions to point to proper file

### DIFF
--- a/responses/01_label-trigger.md
+++ b/responses/01_label-trigger.md
@@ -28,7 +28,7 @@ In a GitHub Actions workflow, the `on` step defines what causes the workflow to 
 ### :keyboard: Activity: Configure the workflow trigger based on an a label being added
 
 1. Edit this file
-2. Change the name of the directory `CHANGETHIS` to `workflows`, so the title of this file with the path is `.github/workflows/staging-workflow.yml`
+2. Change the name of the directory `CHANGETHIS` to `workflows`, so the title of this file with the path is `.github/workflows/deploy-staging.yml`
 3. Edit the contents of this file to trigger on a label
 
 Your result should look like this:

--- a/responses/03_workflow-steps.md
+++ b/responses/03_workflow-steps.md
@@ -29,7 +29,7 @@ The course [_Using GitHub Actions for CI_](https://lab.github.com/githubtraining
 1. Click **Add a new secret** again.
 1. Name the second secret **AWS_SECRET_KEY** and paste the value from the Secret access key generated on AWS.
 1. Click **Add secret**
-1. Back in this pull request, edit the `.github/workflows/staging-workflow.yml` file to use a new action 
+1. Back in this pull request, edit the `.github/workflows/deploy-staging.yml` file to use a new action 
     ```yml
     - name: Deploy to AWS
       uses: github/deploy-nodejs@master


### PR DESCRIPTION
![](https://i.imgur.com/3fhAMxY.png)

As the bot points out, Step 2 is expecting the file name`deploy-staging.yml` to be committed :point_down: and not the `staging-workflow.yml` as highlighted :point_up: in Step 2.

![](https://i.imgur.com/WiXoYpu.png)

:warning: :warning:  On the other hand, when I took the course for a second time, the course moved forward to **Step 2: Trigger a job on specific labels** when the file name was changed to`staging-workflow.yml`. But immediately after that, an error message popped up stating it needed changes to be made to the `deploy-staging.yml`

![](https://i.imgur.com/tukXUpk.png)

:warning: :warning: **Step 3: Deploy a Node.js app to AWS for the first time** might have the file name wrong too as seen below.

![](https://i.imgur.com/pp9B0Gk.png)