### PR TITLE
Surface info about AWS account being a required step

### DIFF
--- a/course-details.md
+++ b/course-details.md
@@ -7,3 +7,5 @@ In this course, we focus on workflows to deploy pull requests automatically to a
 - Use secrets to store tokens
 - Deploy to staging and production
 - Practice using GitHub Actions
+
+**Please note**: You may need a credit card to create an AWS account. If you're a student, you may also be able to take advantage of the [Student Developer Pack](https://education.github.com/pack) for access to AWS. If you'd like to continue with the course without an AWS account, Learning Lab will still respond, but none of the deployments will work.


### PR DESCRIPTION
This is to prevent users with no access to a credit card from being stuck on Step 3 of the course.