### PR TITLE
Fix course so it can use proper Node runtime

### DIFF
--- a/responses/10_deploy-prod.md
+++ b/responses/10_deploy-prod.md
@@ -55,7 +55,7 @@ jobs:
           path: public
 
       - name: Deploy to AWS
-        uses: docker://admiralawkbar/aws-nodejs:latest
+        uses:  github/deploy-nodejs@master
         env:
           AWS_ACCESS_KEY: {% raw %}${{ secrets.AWS_ACCESS_KEY }}{% endraw %}
           AWS_SECRET_KEY: {% raw %}${{ secrets.AWS_SECRET_KEY }}{% endraw %}

--- a/responses/11_workflow-steps.md
+++ b/responses/11_workflow-steps.md
@@ -76,7 +76,7 @@ jobs:
           path: public
 
       - name: Deploy to AWS
-        uses: docker://admiralawkbar/aws-nodejs:latest
+        uses:  github/deploy-nodejs@master
         env:
           AWS_ACCESS_KEY: {% raw %}${{ secrets.AWS_ACCESS_KEY }}{% endraw %}
           AWS_SECRET_KEY: {% raw %}${{ secrets.AWS_SECRET_KEY }}{% endraw %}


### PR DESCRIPTION
This PR requires [this commit on the template repo](https://github.com/githubtraining/continuous-delivery-aws-template/commit/451075431f80b98f43e57f000b0fa619cb118a2d). The commit on the template repo gets us through the final deployment in the course, but for some reason the version of the action that lives on Dockerhub doesn't support Node 12. This PR changes the last step to use the repo as the source of the action instead and I've verified it works.

This PR fixes #25 